### PR TITLE
Use Ruby 1.8-compatible hash syntax

### DIFF
--- a/lib/pgbackups-archive/storage.rb
+++ b/lib/pgbackups-archive/storage.rb
@@ -10,11 +10,11 @@ class PgbackupsArchive::Storage
 
   def connection
     Fog::Storage.new({
-      provider:              "AWS",
-      aws_access_key_id:     ENV["PGBACKUPS_AWS_ACCESS_KEY_ID"],
-      aws_secret_access_key: ENV["PGBACKUPS_AWS_SECRET_ACCESS_KEY"],
-      region:                ENV["PGBACKUPS_REGION"],
-      persistent:            false
+      :provider              => "AWS",
+      :aws_access_key_id     => ENV["PGBACKUPS_AWS_ACCESS_KEY_ID"],
+      :aws_secret_access_key => ENV["PGBACKUPS_AWS_SECRET_ACCESS_KEY"],
+      :region                => ENV["PGBACKUPS_REGION"],
+      :persistent            => false
     })
   end
 
@@ -23,7 +23,7 @@ class PgbackupsArchive::Storage
   end
 
   def store
-    bucket.files.create key: @key, body: @file, :public => false
+    bucket.files.create :key => @key, :body => @file, :public => false
   end
 
 end


### PR DESCRIPTION
I know the new syntax is sexy, but this quick change makes it work on 1.8.7.
