### PR TITLE
Adjust commentary re pgbackups plans in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,8 @@ Add the gem to your Gemfile and bundle:
 
 Install Heroku addons:
 
-    heroku addons:add pgbackups:plus
+    heroku addons:add pgbackups
     heroku addons:add scheduler:standard
-
-Note: You can use paid-for versions of pgbackups if you'd like, however the dev and basic database offerings only support the free (plus) version.
 
 Apply environment variables:
 


### PR DESCRIPTION
Following suit with Heroku's own [documentation](https://devcenter.heroku.com/articles/pgbackups), this:
- Changes the readme to recommend the default pgbackups addon installation.
- Removes the readme note re paid-for vs. free levels of pgbackups.  All are supported to my knowledge, but the readme shouldn't attempt to keep pace with Heroku's ever changing pricing and support of pgbackups levels to database types.

Closes #6 
