### PR TITLE
Remove deprecated railtie_name

### DIFF
--- a/lib/pgbackups-archive/railtie.rb
+++ b/lib/pgbackups-archive/railtie.rb
@@ -4,7 +4,6 @@ if defined?(Rails)
   else
     module PgbackupsArchive
       class Railtie < Rails::Railtie
-        railtie_name :pgbackups_archive
         rake_tasks do
           load "tasks/pgbackups_archive.rake"
         end


### PR DESCRIPTION
#10 identified that `railtie_name` should be removed, this removes it.
