### PR TITLE
Update gem dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    pgbackups-archive (0.0.4)
-      bundler (~> 1.2.1)
+    pgbackups-archive (0.1.0)
+      bundler (>= 1.2.3)
       fog (>= 1.4.0)
-      heroku (~> 2.32.14)
+      heroku (~> 2.34.0)
       rake (>= 0.9.2.2)
 
 GEM
@@ -16,8 +16,8 @@ GEM
     cane (2.5.2)
       parallel
     coderay (1.0.8)
-    excon (0.16.7)
-    fog (1.6.0)
+    excon (0.16.10)
+    fog (1.9.0)
       builder
       excon (~> 0.14)
       formatador (~> 0.2.0)
@@ -27,7 +27,7 @@ GEM
       net-ssh (>= 2.1.3)
       nokogiri (~> 1.5.0)
       ruby-hmac
-    formatador (0.2.3)
+    formatador (0.2.4)
     guard (1.6.2)
       listen (>= 0.6.0)
       lumberjack (>= 1.0.2)
@@ -37,21 +37,21 @@ GEM
     guard-minitest (0.5.0)
       guard (>= 0.4)
     hashie (1.2.0)
-    heroku (2.32.14)
-      heroku-api (~> 0.3.5)
+    heroku (2.34.0)
+      heroku-api (~> 0.3.7)
       launchy (>= 0.3.2)
       netrc (~> 0.7.7)
       rest-client (~> 1.6.1)
       rubyzip
-    heroku-api (0.3.5)
-      excon (~> 0.16.1)
+    heroku-api (0.3.7)
+      excon (~> 0.16.10)
     launchy (2.1.2)
       addressable (~> 2.3)
     listen (0.7.2)
     lumberjack (1.0.2)
     metaclass (0.0.1)
     method_source (0.8.1)
-    mime-types (1.19)
+    mime-types (1.20.1)
     minitest (4.5.0)
     minitest-reporters (0.14.7)
       ansi
@@ -63,9 +63,9 @@ GEM
     multi_json (1.3.6)
     net-scp (1.0.4)
       net-ssh (>= 1.99.1)
-    net-ssh (2.6.1)
+    net-ssh (2.6.3)
     netrc (0.7.7)
-    nokogiri (1.5.5)
+    nokogiri (1.5.6)
     parallel (0.6.2)
     powerbar (1.0.11)
       ansi (~> 1.4.0)
@@ -74,7 +74,7 @@ GEM
       coderay (~> 1.0.5)
       method_source (~> 0.8)
       slop (~> 3.4)
-    rake (0.9.2.2)
+    rake (10.0.3)
     rb-fsevent (0.9.3)
     rest-client (1.6.7)
       mime-types (>= 1.16)

--- a/pgbackups-archive.gemspec
+++ b/pgbackups-archive.gemspec
@@ -12,10 +12,10 @@ Gem::Specification.new do |s|
   s.summary     = %q{A means of automating Heroku's pgbackups and archiving them to Amazon S3 via the fog gem.}
   s.description = %q{A means of automating Heroku's pgbackups and archiving them to Amazon S3 via the fog gem.}
 
-  s.add_dependency "bundler", "~> 1.2.1"
-  s.add_dependency "fog",    ">= 1.4.0"
-  s.add_dependency "heroku", "~> 2.32.14"
-  s.add_dependency "rake",   ">= 0.9.2.2"
+  s.add_dependency "bundler", ">= 1.2.3"
+  s.add_dependency "fog",     ">= 1.4.0"
+  s.add_dependency "heroku",  "~> 2.34.0"
+  s.add_dependency "rake",    ">= 0.9.2.2"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
- Bugfix bump for `bundler`.
- Leave `fog` where it is (in alignment with `backup` gem's requirement or higher).
- Jump to latest `heroku` client (the gem, not the toolbelt yet).
- Leave `rake` as-is.
