### PR TITLE
S3 server-side encryption based on ENV["PGBACKUPS_SERVER_SIDE_ENCRYPTION...

### DIFF
--- a/lib/pgbackups-archive/storage.rb
+++ b/lib/pgbackups-archive/storage.rb
@@ -23,7 +23,11 @@ class PgbackupsArchive::Storage
   end
 
   def store
-    bucket.files.create :key => @key, :body => @file, :public => false
+    bucket.files.create :key => @key, :body => @file, :public => false, :encryption => self.encryption
+  end
+
+  def encryption
+    return ENV["PGBACKUPS_SERVER_SIDE_ENCRYPTION"].to_s == "true" ? "AES256" : nil
   end
 
 end

--- a/test/lib/pgbackups-archive/storage_test.rb
+++ b/test/lib/pgbackups-archive/storage_test.rb
@@ -30,4 +30,18 @@ describe PgbackupsArchive::Storage do
     storage.store.class.must_equal Fog::Storage::AWS::File
   end
 
+  it "should have server-side encryption off by default" do
+    storage.encryption.must_equal nil
+  end
+
+  describe "server-side encryption is enabled" do
+    before do
+      ENV["PGBACKUPS_SERVER_SIDE_ENCRYPTION"] = "true"
+    end
+
+    it "should set encryption to AES256" do
+      storage.encryption.must_equal "AES256"
+    end
+  end
+
 end


### PR DESCRIPTION
Great gem; exactly what I was looking for and more. Thank you!

I added the ability to take advantage of [AWS S3 Server-Side Encryption](https://aws.amazon.com/blogs/aws/new-amazon-s3-server-side-encryption/) by setting 

```
ENV["PGBACKUPS_SERVER_SIDE_ENCRYPTION"] = true
```

[Fog supports Server-Side Encryption](http://rubydoc.info/gems/fog/Fog/Storage/AWS/File#save-instance_method) via the `{ :encryption => "AES256" }` option.
