### PR TITLE
use AWS S3 server-side encryption (SSE) by default

### DIFF
--- a/lib/pgbackups-archive/storage.rb
+++ b/lib/pgbackups-archive/storage.rb
@@ -23,7 +23,7 @@ class PgbackupsArchive::Storage
   end
 
   def store
-    bucket.files.create :key => @key, :body => @file, :public => false
+    bucket.files.create :key => @key, :body => @file, :public => false, :encryption => "AES256"
   end
 
 end


### PR DESCRIPTION
Use AWS S3 server-side encryption (SSE) by default per #33.

There is an informative discussion of the merits of AWS S3 SSE on [security.stackexchange.com](https://security.stackexchange.com/questions/8765/what-does-amazons-s3-server-side-encryption-protect-against)
