### PR TITLE
Use fog-aws instead of the base fog gem.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,14 +3,13 @@ PATH
   specs:
     pgbackups-archive (0.2.4)
       bundler
-      fog
+      fog-aws
       heroku (>= 2.34.0)
       rake
 
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.2.8)
     actionpack (4.1.6)
       actionview (= 4.1.6)
       activesupport (= 4.1.6)
@@ -33,30 +32,14 @@ GEM
     coderay (1.1.0)
     docile (1.1.5)
     erubis (2.7.0)
-    excon (0.41.0)
+    excon (0.43.0)
     ffi (1.9.6)
-    fission (0.5.0)
-      CFPropertyList (~> 2.2)
-    fog (1.25.0)
-      fog-brightbox (~> 0.4)
-      fog-core (~> 1.25)
-      fog-json
-      fog-profitbricks
-      fog-radosgw (>= 0.0.2)
-      fog-sakuracloud (>= 0.0.4)
-      fog-softlayer
-      fog-terremark
-      fog-vmfusion
-      fog-voxel
-      fog-xml (~> 0.1.1)
-      ipaddress (~> 0.5)
-      nokogiri (~> 1.5, >= 1.5.11)
-      opennebula
-    fog-brightbox (0.6.1)
-      fog-core (~> 1.22)
-      fog-json
-      inflecto
-    fog-core (1.25.0)
+    fog-aws (0.0.6)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (1.27.3)
       builder
       excon (~> 0.38)
       formatador (~> 0.2)
@@ -65,29 +48,6 @@ GEM
       net-ssh (>= 2.1.3)
     fog-json (1.0.0)
       multi_json (~> 1.0)
-    fog-profitbricks (0.0.1)
-      fog-core
-      fog-xml
-      nokogiri
-    fog-radosgw (0.0.3)
-      fog-core (>= 1.21.0)
-      fog-json
-      fog-xml (>= 0.0.1)
-    fog-sakuracloud (0.1.1)
-      fog-core
-      fog-json
-    fog-softlayer (0.3.24)
-      fog-core
-      fog-json
-    fog-terremark (0.0.3)
-      fog-core
-      fog-xml
-    fog-vmfusion (0.0.1)
-      fission
-      fog-core
-    fog-voxel (0.0.1)
-      fog-core
-      fog-xml
     fog-xml (0.1.1)
       fog-core
       nokogiri (~> 1.5, >= 1.5.11)
@@ -101,19 +61,18 @@ GEM
     guard-minitest (2.3.2)
       guard (~> 2.0)
       minitest (>= 3.0)
-    heroku (3.16.0)
+    heroku (3.23.1)
       heroku-api (~> 0.3.19)
       launchy (>= 0.3.2)
       multi_json (~> 1.10.1)
-      netrc (~> 0.7.7)
+      netrc (>= 0.10.0)
       rest-client (= 1.6.7)
       rubyzip (= 0.9.9)
-    heroku-api (0.3.20)
+    heroku-api (0.3.22)
       excon (~> 0.38)
       multi_json (~> 1.8)
     hitimes (1.2.2)
     i18n (0.6.11)
-    inflecto (0.0.2)
     ipaddress (0.8.0)
     json (1.8.1)
     launchy (2.4.3)
@@ -126,7 +85,7 @@ GEM
     metaclass (0.0.4)
     method_source (0.8.2)
     mime-types (2.4.3)
-    mini_portile (0.6.1)
+    mini_portile (0.6.2)
     minitest (5.4.2)
     minitest-rails (2.1.0)
       minitest (~> 5.4)
@@ -136,14 +95,10 @@ GEM
     multi_json (1.10.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (2.9.1)
-    netrc (0.7.9)
-    nokogiri (1.6.4.1)
+    net-ssh (2.9.2)
+    netrc (0.10.2)
+    nokogiri (1.6.5)
       mini_portile (~> 0.6.0)
-    opennebula (4.10.1)
-      json
-      nokogiri
-      rbvmomi
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -160,10 +115,6 @@ GEM
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
-    rbvmomi (1.8.2)
-      builder
-      nokogiri (>= 1.4.1)
-      trollop
     rest-client (1.6.7)
       mime-types (>= 1.16)
     rubyzip (0.9.9)
@@ -177,7 +128,6 @@ GEM
     thread_safe (0.3.4)
     timers (4.0.1)
       hitimes
-    trollop (2.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
 

--- a/lib/pgbackups-archive/storage.rb
+++ b/lib/pgbackups-archive/storage.rb
@@ -1,4 +1,4 @@
-require "fog"
+require "fog/aws"
 require "open-uri"
 
 class PgbackupsArchive::Storage

--- a/pgbackups-archive.gemspec
+++ b/pgbackups-archive.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_runtime_dependency "bundler"
-  s.add_runtime_dependency "fog"
+  s.add_runtime_dependency "fog-aws"
   s.add_runtime_dependency "heroku", ">= 2.34.0"
   s.add_runtime_dependency "rake"
 


### PR DESCRIPTION
Fog has been splitting out it's providers into separate gems and the
`fog` gem is becoming a metapackage for all of the providers. Since
pgbackups-archive is hard coded to use AWS it should use the (recently
released) fog-aws gem instead.

This has the advantage of only needing to pull in those pieces of fog
that are actually used and not having to pull in 10-20 other gems that
fog depends on.