### PR TITLE
If PGBACKUPS_APP env var is not set a confusing exception is thrown

### DIFF
--- a/lib/pgbackups-archive/job.rb
+++ b/lib/pgbackups-archive/job.rb
@@ -13,6 +13,7 @@ class PgbackupsArchive::Job
   end
 
   def initialize(attrs={})
+    raise ArgumentError, "You must set ENV['PGBACKUPS_APP'] to the name of your app" if ENV["PGBACKUPS_APP"].nil?
     Heroku::Command.load
     @client = Heroku::Command::Pg.new([], :app => ENV["PGBACKUPS_APP"])
   end


### PR DESCRIPTION
To construct the proper URL the Heroku API needs the application name. Right now if it's not set pgbackups-archive will simply pass in nil which results in `RestClient::ResourceNotFound: 404 Resource Not Found`, which I found misleading. Note that if `PGBACKUPS_AWS_ACCESS_KEY_ID`, for example, is not set it does throw an exception.

This fix throws an exception if `PGBACKUPS_APP` is not set.
