### PR TITLE
Allow to tell app and database from rake params 

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ A good security measure would be to use a dedicated set of AWS credentials with 
 
 Then specify `rake pgbackups:archive` as a task you would like to run at any of the available intervals.
 
+### Using the same clock for do backups on multiple apps
+
+If you don't use the `PGBACKUPS_APP` env var, you can call the task with params.
+
+
+    rake pgbackups:archive[your-app-name]
+
+
+If you want to do a backup for no `DATABASE_URL` you can execute:
+
+    rake pgbackups:archive[your-app-name,HEROKU_POSTGRESQL_BLACK_URL]
+
 ### Loading the Rake task
 
 If you're using this gem in a Rails 3 app the rake task will be automatically loaded via a Railtie.

--- a/lib/pgbackups-archive/storage.rb
+++ b/lib/pgbackups-archive/storage.rb
@@ -19,7 +19,12 @@ class PgbackupsArchive::Storage
   end
 
   def bucket
-    connection.directories.get ENV["PGBACKUPS_BUCKET"]
+    directory = connection.directories.get ENV["PGBACKUPS_BUCKET"]
+    directory = connection.directories.create(
+        :key => ENV["PGBACKUPS_BUCKET"],
+        :public => false
+    ) if directory.nil?
+    directory
   end
 
   def store

--- a/lib/tasks/pgbackups_archive.rake
+++ b/lib/tasks/pgbackups_archive.rake
@@ -1,8 +1,14 @@
+
 namespace :pgbackups do
 
   desc "Capture a Heroku PGBackups backup and archive it to Amazon S3."
-  task :archive do
-    PgbackupsArchive::Job.call
+
+  task :archive, [:app, :database] do |t, args|
+
+    args.with_defaults(app: ENV['PGBACKUPS_APP'])
+    args.with_defaults(database: ENV['PGBACKUPS_DATABASE'])
+
+    PgbackupsArchive::Job.new(:app => args.app, :database => args.database).call
   end
 
 end


### PR DESCRIPTION
Hi Kenny,

I want to share our changes with you. Basically we allowed to tell the app name to backup in params because we have too many apps. For the same reason we used the app name in the directory name in the bucket.

Regards,
Antonio.