### PR TITLE
allow alternative s3 key prefix via ENV['PGBACKUPS_PREFIX']

### DIFF
--- a/lib/pgbackups-archive/job.rb
+++ b/lib/pgbackups-archive/job.rb
@@ -93,9 +93,13 @@ class PgbackupsArchive::Job
     File.open(temp_file, "r")
   end
 
+  def prefix
+    ENV["PGBACKUPS_PREFIX"].chomp('/') || "pgbackups/#{environment}"
+  end
+
   def key
     timestamp = created_at.gsub(/\/|\:|\.|\s/, "-").concat(".dump")
-    ["pgbackups", environment, timestamp].compact.join("/")
+    [prefix, timestamp].compact.join("/")
   end
 
   def pgbackups_to_keep


### PR DESCRIPTION
instead of having the prefix hard-coded to "pgbackups/#{environment}",
have the prefix configured by the environment variable PGBACKUPS_PREFIX