### PR TITLE
Set multipart_chunk_size for fog/aws

### DIFF
--- a/lib/pgbackups-archive/storage.rb
+++ b/lib/pgbackups-archive/storage.rb
@@ -23,7 +23,7 @@ class PgbackupsArchive::Storage
   end
 
   def store
-    bucket.files.create :key => @key, :body => @file, :public => false, :encryption => "AES256"
+    bucket.files.create :key => @key, :body => @file, :public => false, :encryption => "AES256", :multipart_chunk_size => 5242880
   end
 
 end

--- a/lib/pgbackups-archive/storage.rb
+++ b/lib/pgbackups-archive/storage.rb
@@ -23,7 +23,7 @@ class PgbackupsArchive::Storage
   end
 
   def store
-    bucket.files.create :key => @key, :body => @file, :public => false, :encryption => "AES256", :multipart_chunk_size => 5242880
+    bucket.files.create :key => @key, :body => @file, :public => false, :encryption => "AES256", :multipart_chunk_size => 104857600
   end
 
 end


### PR DESCRIPTION
From http://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html:

>
In general, when your object size reaches 100 MB, you should consider using multipart uploads instead of uploading the object in a single operation.

Solution: fog/fog#824 (comment)
